### PR TITLE
Uses Ingress instead of LoadBalancer

### DIFF
--- a/k8s/musicstore.yml
+++ b/k8s/musicstore.yml
@@ -386,4 +386,30 @@ spec:
     targetPort: 8080
   selector:
     app: musicstore
-  type: LoadBalancer
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: musicstore
+  namespace: musicstore
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+    kubernetes.io/tls-acme: "true"
+    kubernetes.io/ingress.class: contour
+spec:
+  rules:
+  - host: musicstore.serrano.tanzu.shortrib.io
+    http:
+      paths:
+      - backend:
+          service:
+            name: musicstore
+            port:
+              number: "8080"
+        pathType: Prefix
+        path: /
+  tls:
+  - hosts:
+    - musicstore.serrano.tanzu.shortrib.io
+    secretName: musicstore.serrano.tanzu.shortrib.io-tls
+


### PR DESCRIPTION
TL;DR
-----

Adds an ingress for the Music Store application

Details
-------

Updates the deployment artifacts to use an Ingress for the Music
Store application. This eliminates the need for the `LoadBalancer`
service type for the `musicstore` service, so we change that back
to the default `ClusterIP`.
