### PR TITLE
Corrects the datatype for ingress port

### DIFF
--- a/k8s/musicstore.yml
+++ b/k8s/musicstore.yml
@@ -405,7 +405,7 @@ spec:
           service:
             name: musicstore
             port:
-              number: "8080"
+              number: 8080
         pathType: Prefix
         path: /
   tls:


### PR DESCRIPTION
TL;DR
-----

Uses a number rather than a string to specify the ingress port

Details
-------

Fixes an error on the Ingress controller that was using a string
instead of an integer to specify the port. This was an artifact of
an old template I was using that I incompletely upgraded from the
beta Ingress API to the final version.
