### PR TITLE
Specifies the correct cluster issuer

### DIFF
--- a/k8s/musicstore.yml
+++ b/k8s/musicstore.yml
@@ -393,7 +393,7 @@ metadata:
   name: musicstore
   namespace: musicstore
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-production
+    cert-manager.io/cluster-issuer: letsencrypt-contour-cluster-issuer
     kubernetes.io/tls-acme: "true"
     kubernetes.io/ingress.class: contour
 spec:


### PR DESCRIPTION
TL;DR
-----

Fixes the Ingress object to use the correct cluster issuer

Details
-------

Replaces the cluster issuer annotation on the Music Store Ingress
to use the issue that is configured within the cluster vs. the
default in the template I used to generate the Ingress object. The
name in the template was the one I was using in my home lab which
wasn't right.
