### PR TITLE
Removes namespace from role-binding

### DIFF
--- a/k8s/musicstore.yml
+++ b/k8s/musicstore.yml
@@ -32,7 +32,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: musicstore
-  namespace: musicstore
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
TL;DR
-----

Drops the namespace qualification on the role binding that allows
the musicstore service account to access configs

Details
-------

Deletes the namespace for the service account in the role binding
to keep the manifest agnostic to the namespace it's applied to. I
saw an issue with this when deploying an instance for security
scanning. Calls to the Kubernets API were returning a 403, which
had been happening in the production namespace until I added the
correct role and rolebinding.

By removing the namespace, the binding defaults to the named
service account in the same namespace. This is consistnet with the
rest of the manfiest which omits namespaces on all objects. I went
this way after briefly considering paramaterizing the binding with
a parameter for the namespace. I dismissed that option to keep
things consistent across all objects.
