### PR TITLE
Switches to a single parameter for images

### DIFF
--- a/k8s/musicstore.yml
+++ b/k8s/musicstore.yml
@@ -75,7 +75,7 @@ spec:
       serviceAccountName: musicstore
       containers:
       - name: musicservice
-        image: #@ "{}/{}/{}".format(data.values.registry.host, data.values.registry.project, data.values.musicstore.serviceImage)
+        image: #@ data.values.musicstore.serviceImage
         ports:
         - containerPort: 8080
         env:
@@ -111,7 +111,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: musicservice
-        image: #@ "{}/{}/{}".format(data.values.registry.host, data.values.registry.project, data.values.musicstore.serviceImage)
+        image: #@ data.values.musicstore.serviceImage
         ports:
         - containerPort: 8080
         env:
@@ -157,7 +157,7 @@ spec:
       serviceAccountName: musicstore
       containers:
       - name: orderservice
-        image: #@ "{}/{}/{}".format(data.values.registry.host, data.values.registry.project, data.values.musicstore.orderImage)
+        image: #@ data.values.musicstore.orderImage
         ports:
         - containerPort: 8080
         env:
@@ -193,7 +193,7 @@ spec:
       serviceAccountName: musicstore
       containers:
       - name: musicservice
-        image: #@ "{}/{}/{}".format(data.values.registry.host, data.values.registry.project, data.values.musicstore.orderImage)
+        image: #@ data.values.musicstore.orderImage
         ports:
         - containerPort: 8080
         env:
@@ -239,7 +239,7 @@ spec:
       serviceAccountName: musicstore
       containers:
       - name: shoppingcartservice
-        image: #@ "{}/{}/{}".format(data.values.registry.host, data.values.registry.project, data.values.musicstore.cartImage)
+        image: #@ data.values.musicstore.cartImage
         ports:
         - containerPort: 8080
         env:
@@ -275,7 +275,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: musicservice
-        image: #@ "{}/{}/{}".format(data.values.registry.host, data.values.registry.project, data.values.musicstore.cartImage)
+        image: #@ data.values.musicstore.cartImage
         ports:
         - containerPort: 8080
         env:
@@ -321,7 +321,7 @@ spec:
       serviceAccountName: musicstore
       containers:
       - name: musicstore
-        image: #@ "{}/{}/{}".format(data.values.registry.host, data.values.registry.project, data.values.musicstore.uiImage)
+        image: #@ data.values.musicstore.uiImage
         ports:
         - containerPort: 8080
         env:
@@ -357,7 +357,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: musicservice
-        image: #@ "{}/{}/{}".format(data.values.registry.host, data.values.registry.project, data.values.musicstore.uiImage)
+        image: #@ data.values.musicstore.uiImage
         ports:
         - containerPort: 8080
         env:


### PR DESCRIPTION
TL;DR
-----

Uses a single parameter for each image rather than registry,
project, and image components

Details
-------

Reverses course on how to specify the images for each deployment
and job. I was using three component parameters for the registry,
project, and image but ran into difficulty with then when I
switched the pipeline to read the image from the build service
Kubernetes objects (since the status has the entire reference as
one field).

With this change, the value of the image from the `Image` object
status can be used directly without breaking it into pieces.
